### PR TITLE
feat: hover기능구현

### DIFF
--- a/LLATROF/articles/templates/articles/index.html
+++ b/LLATROF/articles/templates/articles/index.html
@@ -4,7 +4,7 @@
 <div>
     {% for article in articles %}
         <a href="{{ article.goods_url }}">
-            <img src="{{ article.goods_img_url }}" >
+            <img Class="zoom" src="{{ article.goods_img_url }}" >
         </a>
     {% endfor %}
 </div>

--- a/LLATROF/templates/base.html
+++ b/LLATROF/templates/base.html
@@ -4,9 +4,21 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+    <link rel="stylesheet" href="style.css">
     <title>Document</title>
+    <style>
+        .zoom {
+          transition: transform .2s; /* Animation */
+        }
+        
+        .zoom:hover {
+          transform: scale(2); /* (150% zoom - Note: if the zoom is too large, it will go outside of the viewport) */
+        }
+    </style>
 </head>
 <body>
     {% block content %}{% endblock content %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/LLATROF/templates/base.html
+++ b/LLATROF/templates/base.html
@@ -4,21 +4,18 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
-    <link rel="stylesheet" href="style.css">
     <title>Document</title>
     <style>
         .zoom {
-          transition: transform .2s; /* Animation */
+          transition: transform .2s;
         }
         
         .zoom:hover {
-          transform: scale(2); /* (150% zoom - Note: if the zoom is too large, it will go outside of the viewport) */
+          transform: scale(2);
         }
     </style>
 </head>
 <body>
     {% block content %}{% endblock content %}
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
각 Image 마다 hover 기능 구현.

목적
 - 고객들이 확대된 Image를 봄으로써 사이트에 직접 들어가지 않고 판단하기 위함으로 구현.

구현
 - css style을 이용하였고, 외부참조방식을 사용할 경우 css 파일을 만들어야 하기에 번거로움이 있겠다는 생각으로 내부참조방식을 사용.
 - head 에 .zoom과 .zoom:hover 두개로 구분하여 transition 에 애니메이션식으로 '0.2초동안 확대를 하겠다'의 코드를 구현, transform에 '규모를 2배로 확대하겠다'의 의미를 가짐. scale(2)라는 말은 200% 확대의 의미와 동일.
 - 각각의 이미지 파일에 적용시켜야 하기 때문에 index.html에 img tag에 Class="zoom"을 추가함.

에러사항
- Class="zoom"을 base.html의 body 부분에 적어주며 div로 감싸주었더니 이미지 전체파일이 하나로 적용돼 zoom발생.

 