### PR TITLE
Category, Brand Filtering 기능 구현

### DIFF
--- a/LLATROF/articles/templates/articles/brand.html
+++ b/LLATROF/articles/templates/articles/brand.html
@@ -1,0 +1,18 @@
+<h1>Brand</h1>
+<div>
+    {% for brand in brands_list %}
+        <li> 
+            <a href="{% url 'articles:category_brand' brand %}">
+            {{ brand }}
+        </a> 
+        </li>
+    {% endfor %}
+</div>
+
+<div>
+    {% for goods in goods_list %}
+        <a href="{{ goods.goods_url }}">
+            <img src="{{ goods.goods_img_url }}" alt="">
+        </a>
+    {% endfor %}
+</div>

--- a/LLATROF/articles/templates/articles/category.html
+++ b/LLATROF/articles/templates/articles/category.html
@@ -1,6 +1,6 @@
 <h1>Category</h1>
 <div>
-    {% for category in cetegories %}
+    {% for category in category_list %}
         <li> 
             <a href="{% url 'articles:category_goods' category %}">
             {{ category }}

--- a/LLATROF/articles/templates/articles/category.html
+++ b/LLATROF/articles/templates/articles/category.html
@@ -1,0 +1,18 @@
+<h1>Category</h1>
+<div>
+    {% for category in cetegories %}
+        <li> 
+            <a href="{% url 'articles:category_goods' category %}">
+            {{ category }}
+        </a> 
+        </li>
+    {% endfor %}
+</div>
+
+<div>
+    {% for goods in goods_list %}
+        <a href="{{ goods.goods_url }}">
+            <img src="{{ goods.goods_img_url }}" alt="">
+        </a>
+    {% endfor %}
+</div>

--- a/LLATROF/articles/urls.py
+++ b/LLATROF/articles/urls.py
@@ -4,4 +4,6 @@ from . import views
 app_name = 'articles'
 urlpatterns = [
     path('', views.index, name='index'),
+    path('category/', views.category, name='category'),
+    path('category/<category>/', views.category_goods, name='category_goods'),
 ]

--- a/LLATROF/articles/urls.py
+++ b/LLATROF/articles/urls.py
@@ -6,4 +6,6 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('category/', views.category, name='category'),
     path('category/<category>/', views.category_goods, name='category_goods'),
+    path('brand/', views.brand, name='brand'),
+    path('brand/<brand>/', views.brand_goods, name='category_brand'),
 ]

--- a/LLATROF/articles/views.py
+++ b/LLATROF/articles/views.py
@@ -31,3 +31,24 @@ def category_goods(request, category):
         'goods_list': goods_list,
     }
     return render(request, 'articles/category.html', context)
+
+def brand(request):
+    brands = Article.objects.values('goods_brand').distinct()
+    brands_list = []
+    for brand in brands:
+        brand = brand['goods_brand']
+        brands_list.append(brand)
+    context = {
+        'brands_list': brands_list,
+    }
+    
+    return render(request, 'articles/brand.html', context)
+
+def brand_goods(request, brand):
+    goods_list = Article.objects.all().filter(goods_brand=brand)
+    
+    context = {
+        'goods_list': goods_list,
+    }
+    print(goods_list)
+    return render(request, 'articles/brand.html', context)

--- a/LLATROF/articles/views.py
+++ b/LLATROF/articles/views.py
@@ -8,3 +8,26 @@ def index(request):
         'articles': articles,
     }
     return render(request, 'articles/index.html', context)
+
+def category(request):
+    categorise = Article.objects.values('goods_category').distinct()
+
+    category_list = []
+    for category in categorise:
+        category = category['goods_category']
+        category_list.append(category)
+
+    context = {
+        'cetegories': category_list,
+    }
+    
+    return render(request, 'articles/category.html', context)
+
+
+def category_goods(request, category):
+    goods_list = Article.objects.all().filter(goods_category=category)
+    
+    context = {
+        'goods_list': goods_list,
+    }
+    return render(request, 'articles/category.html', context)

--- a/LLATROF/articles/views.py
+++ b/LLATROF/articles/views.py
@@ -9,6 +9,15 @@ def index(request):
     }
     return render(request, 'articles/index.html', context)
 
+#######################################
+#
+# by. JaeHyeon (22/1O/26)
+# category = goods_category 를 분류하기 위한 함수
+# args ->
+# categorise = Article Table 내 goods_category Field 를 중복 제거한 QuerySetList
+# category_list = goods_category 만 분류한 List
+#
+#######################################
 def category(request):
     categorise = Article.objects.values('goods_category').distinct()
 
@@ -18,12 +27,19 @@ def category(request):
         category_list.append(category)
 
     context = {
-        'cetegories': category_list,
+        'category_list': category_list,
     }
     
     return render(request, 'articles/category.html', context)
 
-
+#######################################
+#
+# by. JaeHyeon (22/1O/26)
+# category_goods = category 기준으로 분류된 goods 만 rendering 하는 함수
+# args ->
+# goods_list = Article Table 내 goods_category 기준으로 variable routing 을 통해 받은 category(:str) 를 filtering 한 QuerySetList
+#
+#######################################
 def category_goods(request, category):
     goods_list = Article.objects.all().filter(goods_category=category)
     
@@ -32,6 +48,15 @@ def category_goods(request, category):
     }
     return render(request, 'articles/category.html', context)
 
+#######################################
+#
+# by. JaeHyeon (22/1O/26)
+# brand = goods_brand 를 분류하기 위한 함수
+# args ->
+# brands = Article Table 내 goods_brand Friled 를 중복 제거한 QuerySetList
+# brands_list = goods_brand 만 분류한 List
+#
+#######################################
 def brand(request):
     brands = Article.objects.values('goods_brand').distinct()
     brands_list = []
@@ -44,11 +69,18 @@ def brand(request):
     
     return render(request, 'articles/brand.html', context)
 
+#######################################
+#
+# by. JaeHyeon (22/1O/26)
+# brand_goods = brand 기준으로 분류된 goods 만 rendering 하는 함수
+# args ->
+# goods_list = Article Table 내 goods_brand 기준으로 variable routing 을 통해 받은 brand(:str) 를 filtering 한 QuerySetList
+#
+#######################################
 def brand_goods(request, brand):
     goods_list = Article.objects.all().filter(goods_brand=brand)
     
     context = {
         'goods_list': goods_list,
     }
-    print(goods_list)
     return render(request, 'articles/brand.html', context)


### PR DESCRIPTION
- 구현 목적 : 카테고리 및 브랜드 분류에 따른 유저 편의성 증대

- 구현 개요
  - Article Table 내 `goods_category` , `goods_brand` 를 DISTINCT 및 FILTERING 

- 코드 설명
  - 각 코드 내 커맨트로 대체
    -  `Commits` 또는 `Files changed` 확인

- 참고 사항
  - 해당 PR 에 `articles - model` 부분 `goods_category`, `goods_brand` 는 반영되어 있지 않음
해당 필드가 추가된 부분은 이전 PR 에 반영되어있어서 이전 PR 먼저 Merge 필요

  - 카테고리 - 트레이닝/조거 > 트레이닝 으로 크롤링할 때 수정해서 가져오는 걸로 로직 추가해야함
  - 트레이닝/조거 로 DB 에 import 시, ~~~/articels/category/**(트레이닝/조거)**
로 Django 내부적으로 variable routing 시 자동변경하기 때문에 해당 필드(`(트레이닝/조거)`) 가 없다고 에러 코드 발생

    - 해당 부분은 [이전 PR ](https://github.com/JAY-Winter/LLATROF/pull/3) 에 구현해두었습니다.